### PR TITLE
Update elkazur.txt

### DIFF
--- a/events/elkazur.txt
+++ b/events/elkazur.txt
@@ -57,7 +57,7 @@ country_event = {
 	ai_chance = { factor = 100 }
 		add_country_modifier = {
 			name = consuming_dread
-			duration = 7300
+			duration = 3650
 		}
 	}
 
@@ -66,7 +66,7 @@ country_event = {
 	ai_chance = { factor = 100 }
 		add_country_modifier = {
 			name = foundation_stability
-			duration = 7300
+			duration = 3650
 		}
 	}
 


### PR DESCRIPTION
Nerf Elkazur second mission duration to ten years.
We can change it back later. I didn't like how good it felt when I played.